### PR TITLE
Feature/use media type only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- WithFormats no longer accepts formats with semi-colons (;).  Matching parsers is done only one media type.
+- Parser.Parse strips any MIME parameters prior to looking up the parser associated with a format
 
 ## [v0.0.3]
 - clorthofx package provides integration with go.uber.org/fx [#20](https://github.com/xmidt-org/clortho/issues/20)

--- a/options.go
+++ b/options.go
@@ -79,7 +79,7 @@ func (pof parserOptionFunc) applyToParsers(ps *parsers) error { return pof(ps) }
 func WithFormats(p Parser, formats ...string) ParserOption {
 	return parserOptionFunc(func(ps *parsers) (err error) {
 		for _, f := range formats {
-			if strings.IndexByte(f, ':') >= 0 {
+			if strings.IndexByte(f, ';') >= 0 {
 				err = multierr.Append(
 					err,
 					MIMEParametersNotSupportedError{

--- a/options.go
+++ b/options.go
@@ -25,18 +25,19 @@ import (
 	"go.uber.org/multierr"
 )
 
-// MIMEParametersNotSupportedError is returned when an attempt is made to register a parser
-// with a format that contains a semi-colon (';').  Formats may only be file suffixes
-// or media types.
-type MIMEParametersNotSupportedError struct {
+// InvalidFormatError indicates that a format cannot be associated with a Parser
+// because the format string is invalid.  For example, format strings that contain
+// semi-colons (;) are invalid because matching a Parser by MIME parameters is
+// not supported.
+type InvalidFormatError struct {
 	Format string
 }
 
 // Error satisfies the error interface.
-func (mpnse MIMEParametersNotSupportedError) Error() string {
+func (ife InvalidFormatError) Error() string {
 	return fmt.Sprintf(
-		"Invalid format [%s]:  MIME parameters are not supported",
-		mpnse.Format,
+		"Cannot register invalid format [%s]",
+		ife.Format,
 	)
 }
 
@@ -82,7 +83,7 @@ func WithFormats(p Parser, formats ...string) ParserOption {
 			if strings.IndexByte(f, ';') >= 0 {
 				err = multierr.Append(
 					err,
-					MIMEParametersNotSupportedError{
+					InvalidFormatError{
 						Format: f,
 					},
 				)

--- a/parser.go
+++ b/parser.go
@@ -25,11 +25,13 @@ import (
 	"go.uber.org/multierr"
 )
 
+// UnsupportedFormatError indicates that a Parser cannot parse a given format.
 type UnsupportedFormatError struct {
 	Format string
 }
 
-func (ufe *UnsupportedFormatError) Error() string {
+// Error implements the error interface.
+func (ufe UnsupportedFormatError) Error() string {
 	return fmt.Sprintf("No parser configured for format %s", ufe.Format)
 }
 
@@ -65,7 +67,7 @@ func (ps *parsers) Parse(format string, content []byte) (keys []Key, err error) 
 	if p, ok := ps.p[formatKey]; ok {
 		keys, err = p.Parse(formatKey, content)
 	} else {
-		err = &UnsupportedFormatError{
+		err = UnsupportedFormatError{
 			Format: format, // include the original format string, for easier debugging
 		}
 	}

--- a/parser.go
+++ b/parser.go
@@ -120,7 +120,11 @@ func NewParser(options ...ParserOption) (Parser, error) {
 	)
 
 	for _, o := range options {
-		multierr.Append(err, o.applyToParsers(ps))
+		err = multierr.Append(err, o.applyToParsers(ps))
+	}
+
+	if err != nil {
+		ps = nil
 	}
 
 	return ps, err

--- a/parser_test.go
+++ b/parser_test.go
@@ -363,6 +363,15 @@ func (suite *ParserSuite) TestCustomParser() {
 	suite.ErrorIs(err, expectedError)
 }
 
+func (suite *ParserSuite) TestMIMEParameters() {
+	p, err := NewParser(
+		WithFormats(nil, "application/json;charset=utf-8"),
+	)
+
+	suite.Nil(p)
+	suite.Error(err)
+}
+
 func TestParser(t *testing.T) {
 	suite.Run(t, new(ParserSuite))
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -225,6 +225,7 @@ func (suite *ParserSuite) testListPEM(format string) {
 func (suite *ParserSuite) TestListPEM() {
 	suite.Run(SuffixPEM, func() { suite.testListPEM(SuffixPEM) })
 	suite.Run(MediaTypePEM, func() { suite.testListPEM(MediaTypePEM) })
+	suite.Run(MediaTypePEM+";charset=us-ascii", func() { suite.testListPEM(MediaTypePEM + ";charset=us-ascii") })
 }
 
 func (suite *ParserSuite) testJWK(format string) {
@@ -254,6 +255,7 @@ func (suite *ParserSuite) TestJWK() {
 	suite.Run("RejectSet", func() {
 		suite.Run(SuffixJWK, func() { suite.testJWKRejectSet(SuffixJWK) })
 		suite.Run(MediaTypeJWK, func() { suite.testJWKRejectSet(MediaTypeJWK) })
+		suite.Run(MediaTypeJWK+";charset=utf-8", func() { suite.testJWKRejectSet(MediaTypeJWK + ";charset=utf-8") })
 	})
 }
 
@@ -329,6 +331,7 @@ func (suite *ParserSuite) TestJWKSet() {
 	suite.Run("Invalid", func() {
 		suite.Run(SuffixJWKSet, func() { suite.testJWKSetInvalid(SuffixJWKSet) })
 		suite.Run(MediaTypeJWKSet, func() { suite.testJWKSetInvalid(MediaTypeJWKSet) })
+		suite.Run(MediaTypeJWKSet+";charset=utf-8", func() { suite.testJWKSetInvalid(MediaTypeJWKSet + ";charset=utf-8") })
 	})
 }
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -341,7 +341,7 @@ func (suite *ParserSuite) TestUnsupportedFormat() {
 	keys, err := p.Parse(unsupportedFormat, []byte("does not matter"))
 	suite.Empty(keys)
 
-	var ufe *UnsupportedFormatError
+	var ufe UnsupportedFormatError
 	suite.Require().ErrorAs(err, &ufe)
 	suite.Equal(unsupportedFormat, ufe.Format)
 	suite.Contains(ufe.Error(), unsupportedFormat)
@@ -367,12 +367,17 @@ func (suite *ParserSuite) TestCustomParser() {
 }
 
 func (suite *ParserSuite) TestMIMEParameters() {
+	const formatWithParameters = "application/json;charset=utf-8"
 	p, err := NewParser(
-		WithFormats(nil, "application/json;charset=utf-8"),
+		WithFormats(nil, formatWithParameters),
 	)
 
 	suite.Nil(p)
-	suite.Error(err)
+
+	var ife InvalidFormatError
+	suite.Require().ErrorAs(err, &ife)
+	suite.Equal(formatWithParameters, ife.Format)
+	suite.Contains(ife.Error(), formatWithParameters)
 }
 
 func TestParser(t *testing.T) {


### PR DESCRIPTION
This PR makes sure that MIME parameters are ignored insofar as matching the Parser to use.  It also disallows registering formats with MIME parameters.