### PR TITLE
chore: updated latest go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/xmidt-org/clortho
 
-go 1.23.0
+go 1.24
 
 require (
 	github.com/jtacoma/uritemplates v1.0.0


### PR DESCRIPTION
What's included:
- update go.mod to latest go version
- update shared-go github action to latest version
- update docker build to include arm64 and amd64