### PR TITLE
Fix workflow action pinning and add missing permissions blocks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,11 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  pull-requests: read
+  contents: write
+  packages: write
+
 jobs:
   ci:
     uses: xmidt-org/shared-go/.github/workflows/ci.yml@a98d20363e6225b37af9aa8d2b3c4bdfedbe8020 # v4.8.7

--- a/.github/workflows/proj-xmidt-team.yml
+++ b/.github/workflows/proj-xmidt-team.yml
@@ -11,7 +11,12 @@ on:
     types:
       - opened
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   package:
-    uses: xmidt-org/.github/.github/workflows/proj-template.yml@proj-v1
+    uses: xmidt-org/shared-go/.github/workflows/proj.yml@60838be4a68ca029af165c3d9067aa41f4e8db14 # 2024-12-18
     secrets: inherit


### PR DESCRIPTION
## Summary

Completes the workflow normalization to align with XMiDT ideal state requirements. This PR addresses all remaining items from issue #175.

## Changes

### 1. Added top-level permissions block to `ci.yml`
- `pull-requests: read` - Required to read PR information
- `contents: write` - Required for releases and tagging
- `packages: write` - Required for publishing packages

### 2. Updated `proj-xmidt-team.yml`
- Changed from `xmidt-org/.github` to `xmidt-org/shared-go`
- Updated workflow path from `proj-template.yml` to `proj.yml`
- Pinned to commit SHA `60838be4a68ca029af165c3d9067aa41f4e8db14` instead of `@proj-v1` tag
- Added top-level permissions block:
  - `contents: read` - Required to read repository content
  - `issues: write` - Required to add issues to project board
  - `pull-requests: write` - Required to add PRs to project board

## Testing

- Verified workflow YAML syntax is valid
- Verified SHA pins point to correct commits in shared-go
- All permissions blocks follow XMiDT ideal state checklist requirements

## References

- Fixes #175
- Related to audit findings from consistent-xmidt-repo skill
- Reference implementations: [wrp-go](https://github.com/xmidt-org/wrp-go/tree/main/.github/workflows)

## Checklist

- [x] Update `proj-xmidt-team.yml`: pin to SHA with version comment
- [x] Add top-level `permissions:` block to `ci.yml`
- [x] Add top-level `permissions:` block to `proj-xmidt-team.yml`
- [x] Update `proj-xmidt-team.yml` to use `xmidt-org/shared-go`