### PR TITLE
Add auto-releaser workflow

### DIFF
--- a/.github/workflows/auto-releaser.yml
+++ b/.github/workflows/auto-releaser.yml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2026 Comcast Cable Communications Management, LLC
+# SPDX-License-Identifier: Apache-2.0
+---
+name: 'Auto Releaser'
+
+on:
+  schedule:
+    - cron: '0 12 * * *'  # Run daily at 12:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    uses: xmidt-org/shared-go/.github/workflows/auto-releaser.yml@516d8f2a4f485b08d91c5ac68ffaa8543b8f6bf6 # 2026-03-16
+    secrets: inherit


### PR DESCRIPTION
## Summary

Adds the missing `auto-releaser.yml` workflow to automatically create patch releases on a daily schedule. This aligns with XMiDT ideal state requirements for automated release management.

## Changes

### Created `.github/workflows/auto-releaser.yml`
- ✅ References `xmidt-org/shared-go/.github/workflows/auto-releaser.yml`
- ✅ Pinned to commit SHA `516d8f2a4f485b08d91c5ac68ffaa8543b8f6bf6` (2026-03-16)
- ✅ Runs daily at 12:00 UTC via cron schedule
- ✅ Supports manual dispatch via `workflow_dispatch`
- ✅ Includes top-level `permissions:` block with `contents: write`
- ✅ Includes SPDX headers (FileCopyrightText and License-Identifier)

### Workflow Configuration

```yaml
name: 'Auto Releaser'

on:
  schedule:
    - cron: '0 12 * * *'  # Run daily at 12:00 UTC
  workflow_dispatch:

permissions:
  contents: write

jobs:
  release:
    uses: xmidt-org/shared-go/.github/workflows/auto-releaser.yml@516d8f2a4f485b08d91c5ac68ffaa8543b8f6bf6 # 2026-03-16
    secrets: inherit
```

## How It Works

The auto-releaser workflow:
1. **Runs daily at 12:00 UTC** - Checks for new commits since the last release
2. **Automatically creates patch releases** - If commits are found, creates a new patch version
3. **Can be manually triggered** - Via GitHub Actions UI using workflow_dispatch
4. **Inherits org secrets** - Uses organization-level secrets for authentication

## Benefits

- ✅ **Automated patch releases** - No manual intervention needed for routine updates
- ✅ **Consistent release schedule** - Daily checks ensure timely releases
- ✅ **Manual override available** - Can trigger releases on-demand when needed
- ✅ **Follows XMiDT standards** - Uses shared-go workflow for consistency across repos

## Verification

- ✅ Workflow file follows YAML syntax standards
- ✅ SHA pinning instead of tags for security
- ✅ Proper permissions block included
- ✅ SPDX license headers present

## References

- Fixes #174
- Related to audit findings from consistent-xmidt-repo skill
- Per XMiDT ideal state checklist: "auto-releaser.yml — shared workflow, runs daily at 12:00 UTC + manual dispatch; auto-creates patch releases"

## Checklist

- [x] Create `.github/workflows/auto-releaser.yml`
- [x] Reference `xmidt-org/shared-go` auto-releaser workflow (with SHA pinning)
- [x] Set schedule to daily at 12:00 UTC
- [x] Add manual dispatch trigger
- [x] Add top-level `permissions:` block with `contents: write`
- [x] Include SPDX headers
- [x] Commit and push